### PR TITLE
refactor: Change the backend to `rust` by the mean of `wasm`

### DIFF
--- a/cdc/src/lib.rs
+++ b/cdc/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub enum Month {
     Oct,
     Nov,
@@ -16,30 +16,30 @@ pub enum Month {
     Jui,
     Jul,
     Aout,
-    Sept
+    Sept,
 }
 
-impl fmt::Display for Month {   
+impl fmt::Display for Month {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Month::Oct => write!(f,"Octobre"),
-            Month::Nov => write!(f,"Nov"),
-            Month::Dec => write!(f,"Dec"),
-            Month::Jan => write!(f,"Jan"),
-            Month::Fev => write!(f,"Fev"),
-            Month::Mar => write!(f,"Mar"),
-            Month::Avr => write!(f,"Avr"),
-            Month::Mai => write!(f,"Mai"),
-            Month::Jui => write!(f,"Jui"),
-            Month::Jul => write!(f,"Jul"),
-            Month::Aout => write!(f,"Aout"),
-            Month::Sept => write!(f,"Sept"),
-        }  
+            Month::Oct => write!(f, "Octobre"),
+            Month::Nov => write!(f, "Nov"),
+            Month::Dec => write!(f, "Dec"),
+            Month::Jan => write!(f, "Jan"),
+            Month::Fev => write!(f, "Fev"),
+            Month::Mar => write!(f, "Mar"),
+            Month::Avr => write!(f, "Avr"),
+            Month::Mai => write!(f, "Mai"),
+            Month::Jui => write!(f, "Jui"),
+            Month::Jul => write!(f, "Jul"),
+            Month::Aout => write!(f, "Aout"),
+            Month::Sept => write!(f, "Sept"),
+        }
     }
 }
 
 #[wasm_bindgen]
-#[derive(Debug,Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Mode {
     DEPX,
     DECT,
@@ -58,21 +58,21 @@ pub enum Mode {
 
 impl fmt::Display for Mode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-       match self {
-        Mode::DEPX => write!(f,"DEPX"),
-        Mode::DECT => write!(f,"DECT"),
-        Mode::PRAL => write!(f,"PRAL"),
-        Mode::AOON => write!(f,"AOON"),
-        Mode::AORN => write!(f,"AORN"),
-        Mode::AOOI => write!(f,"AOOI"),
-        Mode::AORI => write!(f,"AORI"),
-        Mode::GRGR => write!(f,"GRGR"),
-        Mode::AOPQ => write!(f,"AOPQ"),
-        Mode::AODE => write!(f,"AODE"),
-        Mode::DAPN => write!(f,"DAPN"),
-        Mode::ANPQ => write!(f,"ANPQ"),
-        Mode::AIPQ => write!(f,"AIPQ"),
-    } 
+        match self {
+            Mode::DEPX => write!(f, "DEPX"),
+            Mode::DECT => write!(f, "DECT"),
+            Mode::PRAL => write!(f, "PRAL"),
+            Mode::AOON => write!(f, "AOON"),
+            Mode::AORN => write!(f, "AORN"),
+            Mode::AOOI => write!(f, "AOOI"),
+            Mode::AORI => write!(f, "AORI"),
+            Mode::GRGR => write!(f, "GRGR"),
+            Mode::AOPQ => write!(f, "AOPQ"),
+            Mode::AODE => write!(f, "AODE"),
+            Mode::DAPN => write!(f, "DAPN"),
+            Mode::ANPQ => write!(f, "ANPQ"),
+            Mode::AIPQ => write!(f, "AIPQ"),
+        }
     }
 }
 
@@ -96,7 +96,11 @@ pub struct AC {
 
 impl fmt::Display for AC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f,"{}, sigle {}, identity {:?}", self.name,self.sigle,self.identity);
+        write!(
+            f,
+            "{}, sigle {}, identity {:?}",
+            self.name, self.sigle, self.identity
+        );
         Ok(())
     }
 }
@@ -121,15 +125,20 @@ impl AC {
         self.papmp.contracts.clone()
     }
 
-    pub fn add_contract(&mut self,seuil: &Seuil, contract: Contract, contract_type: ContractType) -> bool {
+    pub fn add_contract(
+        &mut self,
+        seuil: &Seuil,
+        contract: Contract,
+        contract_type: ContractType,
+    ) -> bool {
         if let Some(procedure) = seuil.find_procedure(&self, contract.amount, contract_type) {
-            let info = procedure.find_info(contract.amount,contract_type);
-            self.papmp.add_contract(Contract{
+            let info = procedure.find_info(contract.amount, contract_type);
+            self.papmp.add_contract(Contract {
                 contract_info: info.clone(),
                 procedure,
                 ..contract
             });
-         return true
+            return true;
         }
         false
     }
@@ -144,10 +153,9 @@ pub struct Seuil {
     level4: Vec<Procedure>,
 }
 
-
 #[wasm_bindgen]
 impl Seuil {
-#[wasm_bindgen(constructor)]
+    #[wasm_bindgen(constructor)]
     pub fn new(
         level1: Vec<Procedure>,
         level2: Vec<Procedure>,
@@ -169,20 +177,21 @@ impl Seuil {
         contract_type: ContractType,
     ) -> Option<Procedure> {
         let mut proc_iter = match ac.identity {
-            Identity::State =>  self.level1.iter(),
-            Identity::Dept =>  self.level2.iter(),
-            Identity::Arron =>  self.level3.iter(), 
-            Identity::Ohter =>  self.level4.iter(),
+            Identity::State => self.level1.iter(),
+            Identity::Dept => self.level2.iter(),
+            Identity::Arron => self.level3.iter(),
+            Identity::Ohter => self.level4.iter(),
         };
-        let proc = proc_iter.find(| &procedure|procedure.has_contract_informations(amount,contract_type));
+        let proc =
+            proc_iter.find(|&procedure| procedure.has_contract_informations(amount, contract_type));
         proc.cloned()
     }
 }
 
 #[wasm_bindgen]
-#[derive(Debug,Clone,Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Procedure {
-    kind: Vec<ProcedureKind> ,
+    kind: Vec<ProcedureKind>,
     contract_info: Vec<ContractInfo>,
     control: bool,
     launch_sign_diff: u8,
@@ -192,7 +201,7 @@ pub struct Procedure {
 impl Procedure {
     #[wasm_bindgen(constructor)]
     pub fn new(
-        kind: Vec<ProcedureKind>,// EnumProcedureKind,
+        kind: Vec<ProcedureKind>, // EnumProcedureKind,
         contract_info: Vec<ContractInfo>,
         control: bool,
         launch_sign_diff: u8,
@@ -209,9 +218,8 @@ impl Procedure {
         self.launch_sign_diff
     }
 
-
     pub fn kind(&self) -> Vec<ProcedureKind> {
-        self.kind.clone() 
+        self.kind.clone()
     }
 
     pub fn has_contract_informations(&self, amount: f64, contract_type: ContractType) -> bool {
@@ -226,7 +234,9 @@ impl Procedure {
     }
 
     pub fn find_info(&self, amount: f64, contract_type: ContractType) -> ContractInfo {
-        let predicate = |c_info: &&ContractInfo| c_info.bound(amount) && c_info.contract_type.contains(&contract_type);
+        let predicate = |c_info: &&ContractInfo| {
+            c_info.bound(amount) && c_info.contract_type.contains(&contract_type)
+        };
         let vec = &self.contract_info;
         match vec.into_iter().find(predicate) {
             Some(contract_info) => contract_info.clone(),
@@ -236,12 +246,12 @@ impl Procedure {
 }
 
 #[wasm_bindgen]
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub struct ContractInfo {
     min: f64,
     max: f64,
-    contract_type: Vec<ContractType>,// EnumContractType,
-    mode: Vec<Mode>
+    contract_type: Vec<ContractType>, // EnumContractType,
+    mode: Vec<Mode>,
 }
 
 #[wasm_bindgen]
@@ -265,7 +275,12 @@ impl ContractInfo {
     }
 
     fn default() -> Self {
-        Self { min:0.0,max:0.0,contract_type: Vec::new(), mode: vec![Mode::AOON] }
+        Self {
+            min: 0.0,
+            max: 0.0,
+            contract_type: Vec::new(),
+            mode: vec![Mode::AOON],
+        }
     }
 
     fn bound(&self, amount: f64) -> bool {
@@ -274,7 +289,7 @@ impl ContractInfo {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, PartialEq,Default,Clone,Copy)]
+#[derive(Debug, PartialEq, Default, Clone, Copy)]
 pub enum ContractType {
     #[default]
     Services,
@@ -286,16 +301,16 @@ pub enum ContractType {
 impl fmt::Display for ContractType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ContractType::Services => write!(f,"S"),
-            ContractType::Fournitures => write!(f,"F"),
-            ContractType::Travaux => write!(f,"T"),
-            ContractType::Prestations => write!(f,"P"),
+            ContractType::Services => write!(f, "S"),
+            ContractType::Fournitures => write!(f, "F"),
+            ContractType::Travaux => write!(f, "T"),
+            ContractType::Prestations => write!(f, "P"),
         }
     }
 }
 
 #[wasm_bindgen]
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub enum ProcedureKind {
     Demandes,
     Alleges,
@@ -316,14 +331,14 @@ impl PAPMP {
         }
     }
 
-    fn add_contract(&mut self,  mut contract: Contract) {
+    fn add_contract(&mut self, mut contract: Contract) {
         contract.no = format!("{:02}", self.contracts.len() + 1);
         self.contracts.push(contract);
     }
 }
 
 #[wasm_bindgen]
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub struct Contract {
     no: String,
     description: String,
@@ -335,7 +350,7 @@ pub struct Contract {
     localization: String,
     delay: u8,
     control: bool,
-    procedure: Procedure ,//EnumProcedureKind,
+    procedure: Procedure, //EnumProcedureKind,
 }
 
 impl fmt::Display for Contract {
@@ -344,14 +359,24 @@ impl fmt::Display for Contract {
         let obj = format!("  - Objet du projet de marché: {}\n", self.description);
         let src = format!("  - Source de financement: {}\n", self.money_provider);
         let amount = format!("  - Montant des crédits disponibles: {}\n", self.amount);
-        let c_type = format!("  - Nature du marché: {:?}\n", self.contract_info.contract_type);
+        let c_type = format!(
+            "  - Nature du marché: {:?}\n",
+            self.contract_info.contract_type
+        );
         let mode = format!("  - Mode de passation: {:?}\n", self.contract_info.mode);
         let launch = format!("  - Période de lancement: {}\n", self.launch);
-        let sign = format!("  - Période probale de signature du marché: {}\n", self.sign);
+        let sign = format!(
+            "  - Période probale de signature du marché: {}\n",
+            self.sign
+        );
         let control = format!("  - Controle a priori de la CNMP: {}\n", self.control);
         let localization = format!("  - Localisation: {}\n", self.localization);
         let delay = format!("  - Délai Prévision-nel D'exécution: {}\n", self.delay);
-        write!(f,"{} {} {} {} {} {} {} {} {} {} {} ", head,obj,src,amount,c_type, mode, launch, sign,control,localization, delay);
+        write!(
+            f,
+            "{} {} {} {} {} {} {} {} {} {} {} ",
+            head, obj, src, amount, c_type, mode, launch, sign, control, localization, delay
+        );
         Ok(())
     }
 }
@@ -409,7 +434,7 @@ impl Contract {
     }
 
     pub fn description(&self) -> String {
-       self.description.clone() 
+        self.description.clone()
     }
 
     pub fn provider(&self) -> MoneyProvider {
@@ -420,7 +445,7 @@ impl Contract {
         self.contract_info.clone()
     }
 
-    pub fn render(&self) -> String{
+    pub fn render(&self) -> String {
         self.to_string()
     }
 
@@ -430,7 +455,7 @@ impl Contract {
 }
 
 #[wasm_bindgen]
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub enum MoneyProvider {
     TI,
     TF,
@@ -442,11 +467,11 @@ pub enum MoneyProvider {
 impl fmt::Display for MoneyProvider {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MoneyProvider::TI => write!(f,"TI"),
-            MoneyProvider::TF => write!(f,"TF"),
-            MoneyProvider::FP => write!(f,"FP"),
-            MoneyProvider::FE => write!(f,"FE"),
-            MoneyProvider::FM => write!(f,"FM"),
+            MoneyProvider::TI => write!(f, "TI"),
+            MoneyProvider::TF => write!(f, "TF"),
+            MoneyProvider::FP => write!(f, "FP"),
+            MoneyProvider::FE => write!(f, "FE"),
+            MoneyProvider::FM => write!(f, "FM"),
         }
     }
 }

--- a/index.html
+++ b/index.html
@@ -12,22 +12,22 @@
 
 <body>
   <header>
-  <h1>Canva numérique de la CNMP</h1>
+    <h1>Canva numérique de la CNMP</h1>
   </header>
   <main>
     <dialog id="contract_dialog">
       <form method="dialog" id="screen1" class="screen1">
         <div class="form-group">
           <label for="description">Objet du projet de marché</label>
-          <input type="description" id="description">
+          <input type="description" id="description" required>
         </div>
         <div class="form-group">
           <label for="amount">Montant des crédits disponible</label>
-          <input type="number" id="amount" required>
+          <input type="number" id="amount" min="3500000" required>
         </div>
         <div class="form-group">
           <label for="contract_type">Nature du marché</label>
-          <select name="contract_type" id="contract_type">
+          <select name="contract_type" id="contract_type" required>
             <option value="0">Services</option>
             <option value="1">Fournitures</option>
             <option value="2">Travaux</option>
@@ -36,7 +36,7 @@
         </div>
         <div class="form-group">
           <label for="money_provider">Source de financement</label>
-          <select name="money_provider" id="money_provider">
+          <select name="money_provider" id="money_provider" required>
             <option value="0">TI</option>
             <option value="1">TF</option>
             <option value="2">FP</option>
@@ -44,15 +44,16 @@
             <option value="4">FM</option>
           </select>
         </div>
+        <button id="next">Next</button>
       </form>
       <form method="dialog" id="screen2" class="screen2" hidden>
         <div class="form-group">
           <label for="contract_localization">Localisation</label>
-          <input name="contract_localization" id="contract_localization"/>
+          <input name="contract_localization" id="contract_localization" required />
         </div>
         <div class="form-group">
           <label for="contract_launch">Période de lancement</label>
-          <select name="contract_launch" id="contract_launch">
+          <select name="contract_launch" id="contract_launch" required>
             <option>Oct</option>
             <option>Nov</option>
             <option>Dec</option>
@@ -69,7 +70,7 @@
         </div>
         <div class="form-control">
           <label for="contract_sign">Periode probable de signature</label>
-          <select name="contract_sign" class="contract_sign" id="contract_sign"></select>
+          <select name="contract_sign" class="contract_sign" id="contract_sign" required></select>
         </div>
         <div class="form-control">
           <label for="contract_control">Contrôle a priori de la CNMP</label>
@@ -77,37 +78,36 @@
         </div>
         <div class="form-control">
           <label for="contract_delay">Delai previsionnel d'execution (mois)</label>
-          <input type="number" name="contract_delay" class="contract_delay" id="contract_delay" min="1" />
+          <input type="number" max="12" name="contract_delay" class="contract_delay" id="contract_delay" min="1"
+            required />
         </div>
         <fieldset class="form-control">
           <legend for="program">Programmation des depenses</legend>
         </fieldset>
+        <button id="prev" type="button" class="prev">Previous</button>
+        <button id="add_contract">Ajouter</button>
       </form>
-      <div class="btns">
-        <button id="prev" class="prev">Previous</button>
-        <button id="next" class="next">Next</button>
-      </div>
-      <button id="add_contract">Ajouter</button>
     </dialog>
     <form id="ac_form">
       <div class="form-control">
         <label for="name">Nom de l'institution</label>
-        <input type="text" name="name" id="name" />
+        <input type="text" class="name" name="name" id="name" required />
       </div>
       <div class="form-control">
         <label for="sigle">Sigle</label>
-        <input type="text" name="sigle" id="sigle" />
+        <input type="text" name="sigle" class="sigle" id="sigle" required />
       </div>
       <div class="form-control">
         <label for="identity">Identite de l'autorite contractante</label>
-        <select type="text" name="identity" id="identity">
-          <option value="level1">Etat, Coll.Departmental</option>
-          <option value="level2">Communes, chefs-lieux de dept</option>
-          <option value="level3">Communes, chefs-lieux d'arrondiss</option>
-          <option value="level4">Autres communes</option>
+        <select type="text" name="identity" class="identity" id="identity" required>
+          <option value="0">Etat, Coll.Departmental</option>
+          <option value="1">Communes, chefs-lieux de dept</option>
+          <option value="2">Communes, chefs-lieux d'arrondiss</option>
+          <option value="3">Autres communes</option>
         </select>
       </div>
       <small>NB: Le tableau doit etre rempli par ordre de priorite chronologique</small>
+      <br>
       <button id="addAcBtn">Ajouter</button>
     </form>
     <button id="show_contract_dialog" hidden>Ajouter un nouveau marché</button>

--- a/index.js
+++ b/index.js
@@ -4,193 +4,215 @@ import { MoneyProvider } from "./cdc/pkg/cdc.js";
 import { Identity } from "./cdc/pkg/cdc.js";
 import { AC } from "./cdc/pkg/cdc.js";
 
+const log = console.log;
+const fmt = Intl.NumberFormat("fr-FR", {
+  style: "currency",
+  currency: "HTG"
+});
+
 //TODO: clean up this mess
 /** @type Seuil */
-let mp = undefined
+let mp;
 /** @type AC */
-let ac = undefined
-/** @type HTMLButtonElement */
-const show_contract_dialog = document.getElementById("show_contract_dialog")
-/** @type HTMLDialogElement */
-const contract_dialog = document.getElementById("contract_dialog")
-/** @type HTMLButtonElement */
-const add_contract_btn = document.getElementById("add_contract")
-show_contract_dialog.hidden = true
-/** @type HTMLFormElement */
+let ac;
+
+const ac_form = document.getElementById("ac_form");
+if (!ac_form || !(ac_form instanceof HTMLFormElement)) throw new Error();
+ac_form.querySelectorAll("input").forEach(input => setupValidation(input));
+
+const show_contract_dialog = document.getElementById("show_contract_dialog");
+if (!show_contract_dialog || !(show_contract_dialog instanceof HTMLButtonElement)) throw new Error();
+show_contract_dialog.hidden = true;
+
+const contract_dialog = document.getElementById("contract_dialog");
+if (!contract_dialog || !(contract_dialog instanceof HTMLDialogElement)) throw new Error();
+
+const add_contract_btn = document.getElementById("add_contract");
+if (!add_contract_btn || !(add_contract_btn instanceof HTMLButtonElement)) throw new Error();
+
 const first_screen = document.getElementById("screen1");
-/** @type HTMLFormElement */
+if (!first_screen || !(first_screen instanceof HTMLFormElement)) throw new Error();
+first_screen.querySelectorAll("input").forEach(input => setupValidation(input));
+
 const second_screen = document.getElementById("screen2");
-/** @type HTMLButtonElement */
+if (!second_screen || !(second_screen instanceof HTMLFormElement)) throw new Error();
+second_screen.querySelectorAll("input").forEach(input => setupValidation(input));
+
 const prev_screen_btn = document.getElementById("prev");
-prev_screen_btn.setAttribute("disabled", true);
-/** @type HTMLButtonElement */
-const next_screen_btn = document.getElementById("next");
-const fmt = Intl.NumberFormat("fr-FR", {
-    style: "currency",
-    currency: "HTG"
-})
+if (!prev_screen_btn || !(prev_screen_btn instanceof HTMLButtonElement)) throw new Error();
+prev_screen_btn.disabled = true;
+
+// const next_screen_btn = document.getElementById("next");
+// if (!next_screen_btn || !(next_screen_btn instanceof HTMLButtonElement)) throw new Error();
+
 
 /** @type Procedure */
-let proc = undefined
+let proc;
+ac_form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  handleAddAcBtnClick(show_contract_dialog, ac_form);
+});
+
+first_screen.addEventListener("submit", event => {
+  event.preventDefault();
+  handleNextScreenBtnClick(first_screen, second_screen, prev_screen_btn, add_contract_btn);
+});
+second_screen.addEventListener("submit", (event) => {
+  event.preventDefault();
+  handleAddContractBtnClick(second_screen, contract_dialog);
+});
 
 init().then(() => {
-    const kind_demande = [ProcedureKind.Demandes]
-    const demande_info = [
-        new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX]),
-        new ContractInfo(3500000, 15000000, [ContractType.Travaux], [Mode.DECT]),
-    ]
-    const kind_allege = [ProcedureKind.Alleges]
-    const allege_info = [
-        new ContractInfo(3500000, 14000000, [ContractType.Services, ContractType.Prestations], [Mode.PRAL]),
-        new ContractInfo(10000000, 16000000, [ContractType.Fournitures], [Mode.PRAL]),
-        new ContractInfo(15000000, 35000000, [ContractType.Travaux], [Mode.PRAL]),
-    ]
-    const kind_gse = [ProcedureKind.Generales, ProcedureKind.Specifiques, ProcedureKind.Exceptionnel]
-    const gse_mode = [Mode.AOON, Mode.AORN, Mode.AOOI, Mode.AORI, Mode.AOPQ, Mode.AODE, Mode.GRGR]
-    const gse_info = [
-        new ContractInfo(14000000, Number.MAX_VALUE, [ContractType.Services, ContractType.Prestations], gse_mode),
-        new ContractInfo(16000000, Number.MAX_VALUE, [ContractType.Fournitures], gse_mode),
-        new ContractInfo(35000000, Number.MAX_VALUE, [ContractType.Travaux], gse_mode),
-    ]
-    const level1_demande = new Procedure(kind_demande, demande_info, false, 2)
-    const level1_allege = new Procedure(kind_allege, allege_info, false, 2)
-    const level1_gse = new Procedure(kind_gse, gse_info, true, 3)
-    const l1_arr = Array.of(level1_demande, level1_allege, level1_gse)
+  const kind_demande = [ProcedureKind.Demandes];
+  const demande_info = [
+    new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX]),
+    new ContractInfo(3500000, 15000000, [ContractType.Travaux], [Mode.DECT]),
+  ];
+  const kind_allege = [ProcedureKind.Alleges];
+  const allege_info = [
+    new ContractInfo(3500000, 14000000, [ContractType.Services, ContractType.Prestations], [Mode.PRAL]),
+    new ContractInfo(10000000, 16000000, [ContractType.Fournitures], [Mode.PRAL]),
+    new ContractInfo(15000000, 35000000, [ContractType.Travaux], [Mode.PRAL]),
+  ];
+  const kind_gse = [ProcedureKind.Generales, ProcedureKind.Specifiques, ProcedureKind.Exceptionnel];
+  const gse_mode = [Mode.AOON, Mode.AORN, Mode.AOOI, Mode.AORI, Mode.AOPQ, Mode.AODE, Mode.GRGR];
+  const gse_info = [
+    new ContractInfo(14000000, Number.MAX_VALUE, [ContractType.Services, ContractType.Prestations], gse_mode),
+    new ContractInfo(16000000, Number.MAX_VALUE, [ContractType.Fournitures], gse_mode),
+    new ContractInfo(35000000, Number.MAX_VALUE, [ContractType.Travaux], gse_mode),
+  ];
+  const level1_demande = new Procedure(kind_demande, demande_info, false, 2);
+  const level1_allege = new Procedure(kind_allege, allege_info, false, 2);
+  const level1_gse = new Procedure(kind_gse, gse_info, true, 3);
+  const l1_arr = Array.of(level1_demande, level1_allege, level1_gse);
 
-    const l2_kind = [ProcedureKind.Demandes]
-    const l2_info = [
-        new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX]),
-        new ContractInfo(3500000, 15000000, [ContractType.Travaux], [Mode.DECT])
-    ]
-    const level2 = new Procedure(l2_kind, l2_info, false, 2)
-    const l2_arr = Array.of(level2)
+  const l2_kind = [ProcedureKind.Demandes];
+  const l2_info = [
+    new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX]),
+    new ContractInfo(3500000, 15000000, [ContractType.Travaux], [Mode.DECT])
+  ];
+  const level2 = new Procedure(l2_kind, l2_info, false, 2);
+  const l2_arr = Array.of(level2);
 
-    const l3_kind = [ProcedureKind.Demandes]
-    const l3_info = [
-        new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX]),
-        new ContractInfo(3500000, 15000000, [ContractType.Travaux], [Mode.DECT])
-    ]
-    const level3 = new Procedure(l3_kind, l3_info, false, 2)
-    const l3_arr = Array.of(level3)
+  const l3_kind = [ProcedureKind.Demandes];
+  const l3_info = [
+    new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX]),
+    new ContractInfo(3500000, 15000000, [ContractType.Travaux], [Mode.DECT])
+  ];
+  const level3 = new Procedure(l3_kind, l3_info, false, 2);
+  const l3_arr = Array.of(level3);
 
-    const l4_kind = [ProcedureKind.Demandes]
-    const l4_info = [
-        new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX])
-    ]
-    const level4 = new Procedure(l4_kind, l4_info, false, 2)
-    const l4_arr = Array.of(level4)
+  const l4_kind = [ProcedureKind.Demandes];
+  const l4_info = [
+    new ContractInfo(3500000, 10000000, [ContractType.Fournitures], [Mode.DEPX])
+  ];
+  const level4 = new Procedure(l4_kind, l4_info, false, 2);
+  const l4_arr = Array.of(level4);
 
-    mp = new Seuil(l1_arr, l2_arr, l3_arr, l4_arr)
+  mp = new Seuil(l1_arr, l2_arr, l3_arr, l4_arr);
 
-    const addAcBtn = document.getElementById("addAcBtn")
-    addAcBtn.addEventListener("click", handleAddAcBtnClick)
+  show_contract_dialog.addEventListener("click", () => contract_dialog.showModal());
+  show_contract_dialog.blur();
 
-    /** @type HTMLButtonElement */
-    show_contract_dialog.addEventListener("click", () => contract_dialog.showModal())
-    show_contract_dialog.blur()
+  prev_screen_btn.addEventListener("click", (event) => {
+    event.preventDefault();
 
-    add_contract_btn.addEventListener("click", handleAddContractBtnClick)
-    next_screen_btn.addEventListener("click", handleNextScreenBtnClick)
-    prev_screen_btn.addEventListener("click", handlePrevScreenBtnClick)
+    first_screen.hidden = false;
+    second_screen.hidden = true;
 
-    add_contract_btn.hidden = true
-})
+    prev_screen_btn.disabled = true;
+    add_contract_btn.disabled = true;
+  });
 
-/**
- * @param {MouseEvent} event
- */
-function handlePrevScreenBtnClick(event) {
-    event.preventDefault()
-
-    first_screen.hidden = false
-    second_screen.hidden = true
-
-    next_screen_btn.removeAttribute("disabled")
-    prev_screen_btn.setAttribute("disabled", true)
-    add_contract_btn.setAttribute("hidden", true)
-}
+});
 
 /**
- * @param {MouseEvent} event
+ * @param {HTMLFormElement} first_screen
+ * @param {HTMLFormElement} second_screen
+ * @param {HTMLButtonElement} prev_screen_btn
+ * @param {HTMLButtonElement} add_contract_btn
+ * @returns void
  */
-function handleNextScreenBtnClick(event) {
-    event.preventDefault()
+function handleNextScreenBtnClick(first_screen, second_screen, prev_screen_btn, add_contract_btn) {
 
-    if (!first_screen.checkValidity()) {
-        console.error("Form isn't valid")
-        return
-    }
+  const contract_type = document.getElementById("contract_type");
+  if (!contract_type || !(contract_type instanceof HTMLSelectElement)) throw new Error();
 
-    /** @type HTMLSelectElement */
-    const contract_type = contract_dialog.querySelector("select#contract_type")
+  const amount = document.getElementById("amount");
+  if (!amount || !(amount instanceof HTMLInputElement)) throw new Error();
+  const val = Number.parseInt(amount.value);
+  if (Number.isNaN(val)) throw new Error();
 
-    if (mp.find_procedure(ac, amount.value, contract_type.selectedIndex) === undefined) {
-        alert("Contract informations is not valid")
-        return
-    }
+  let p = mp.find_procedure(ac, val, contract_type.selectedIndex);
+  if (p === undefined) {
+    alert("Contract informations is not valid");
+    return;
+  }
+  proc = p;
 
-    first_screen.hidden = true
-    second_screen.hidden = false
+  first_screen.hidden = true;
+  second_screen.hidden = false;
 
-    set_second_screen_state()
+  set_second_screen_state();
 
-    next_screen_btn.setAttribute("disabled", true)
-    prev_screen_btn.removeAttribute("disabled")
-    add_contract_btn.removeAttribute("hidden")
+  prev_screen_btn.disabled = false;
+  add_contract_btn.disabled = false;
 }
 
 function set_second_screen_state() {
-    /** @type HTMLSelectElement */
-    const launch_time = document.getElementById("contract_launch")
-    /** @type HTMLSelectElement */
-    const sign_time = document.getElementById("contract_sign")
-    /** @type HTMLInputElement */
-    const control = document.getElementById("contract_control")
+  const launch_time = document.getElementById("contract_launch");
+  if (!launch_time || !(launch_time instanceof HTMLSelectElement)) throw new Error();
+  const sign_time = document.getElementById("contract_sign");
+  if (!sign_time || !(sign_time instanceof HTMLSelectElement)) throw new Error();
+  const control = document.getElementById("contract_control");
+  if (!control || !(control instanceof HTMLInputElement)) throw new Error();
 
-    launch_time.addEventListener("change", () => {
-        sign_time.innerHTML = ""
-        const values = Object.keys(Month).slice(launch_time.selectedIndex, launch_time.selectedIndex + proc.launch_sign_time_diff())
-        values.forEach(value => {
-            const opt = document.createElement("option")
-            opt.value = value,
-                opt.textContent = Month[value]
-            sign_time.appendChild(opt)
-        })
-    })
+  launch_time.addEventListener("change", () => {
+    sign_time.innerHTML = "";
+    const values = Object.keys(Month).slice(launch_time.selectedIndex, launch_time.selectedIndex + proc.launch_sign_time_diff());
+    values.forEach(value => {
+      const opt = document.createElement("option");
+      opt.value = value,
+        opt.textContent = Month[value];
+      sign_time.appendChild(opt);
+    });
+  });
 
-    control.value = proc.control ? "OUI" : "NON"
+  control.value = proc.control() ? "OUI" : "NON";
 
-    launch_time.dispatchEvent(new Event("change"))
+  launch_time.dispatchEvent(new Event("change"));
 }
 
 /**
- * @param {MouseEvent} event
+ * @param {HTMLButtonElement} show_contract_dialog
+ * @param {HTMLFormElement} ac_form
  */
-function handleAddAcBtnClick(event) {
-    event.preventDefault()
+function handleAddAcBtnClick(show_contract_dialog, ac_form) {
+  const name = ac_form.querySelector(".name");
+  if (!name || !(name instanceof HTMLInputElement)) throw new Error();
+  const sigle = ac_form.querySelector(".sigle");
+  if (!sigle || !(sigle instanceof HTMLInputElement)) throw new Error();
+  const state = ac_form.querySelector(".identity");
+  if (!state || !(state instanceof HTMLSelectElement)) throw new Error();
+  let identity = Identity.State;
+  switch (state.selectedIndex) {
+    case 0: identity = Identity.State;
+      break;
+    case 1: identity = Identity.Dept;
+      break;
+    case 2: identity = Identity.Arron;
+      break;
+    case 3: identity = Identity.Ohter;
+      break;
+    default: throw new Error();
+  }
 
-    /** @type {HTMLFormElement} */
-    const ac_form = document.getElementById("ac_form")
-
-    /** @type {HTMLInputElement} */
-    const name = document.getElementById("name")
-    /** @type {HTMLInputElement} */
-    const sigle = document.getElementById("sigle")
-
-    /** @type {HTMLOptionElement} */
-    const identity = document.getElementById("identity")[0]
-
-    if (!ac_form.checkValidity()) {
-        alert("Tout les champs doivent etre remplis")
-        return
-    }
-
-    ac = new AC(name.value, sigle.value, identity.value)
-    console.log(ac.render())
-    // ac_form.reset()
-    ac_form.hidden = true
-    add_ac_banner(name, sigle, identity)
-    show_contract_dialog.hidden = false
+  ac = new AC(name.value, sigle.value, identity);
+  console.log(ac.render());
+  // ac_form.reset()
+  ac_form.hidden = true;
+  // add_ac_banner(name.value, sigle.value, identity);
+  show_contract_dialog.hidden = false;
 }
 
 //TODO: Add a banner showing the current AC
@@ -200,64 +222,69 @@ function handleAddAcBtnClick(event) {
  * @param {Identity} identity 
  */
 function add_ac_banner(name, sigle, identity) {
-    return
-    /** @type HTMLTemplateElement **/
-    const template = document.getElementById("ac_banner")
-    /** @type Node **/
-    const node = template.content.cloneNode(true)
+  const template = document.getElementById("ac_banner");
+  if (!template || !(template instanceof HTMLTemplateElement)) throw new Error();
+  const node = template.content.cloneNode(true);
+  if (!node || !(node instanceof DocumentFragment)) throw new Error();
 
-    /** @type HTMLParagraphElement **/
-    const nameElt = node.querySelector(".name")
-    /** @type HTMLParagraphElement **/
-    const sigleElt = node.querySelector(".sigle")
-    /** @type HTMLParagraphElement **/
-    const identityElt = node.querySelector(".identity")
+  const nameElt = node.querySelector(".name");
+  if (!nameElt || !(nameElt instanceof HTMLParagraphElement)) throw new Error();
+  const sigleElt = node.querySelector(".sigle");
+  if (!sigleElt || !(sigleElt instanceof HTMLParagraphElement)) throw new Error();
+  const identityElt = node.querySelector(".identity");
+  if (!identityElt || !(identityElt instanceof HTMLParagraphElement)) throw new Error();
 
-    nameElt.textContent = name,
-        sigleElt.textContent = sigle,
-        identityElt.textContent = identity
+  nameElt.textContent = name;
+  sigleElt.textContent = sigle;
+  identityElt.textContent = identity.toString();
 }
 
 /**
- * @param {MouseEvent} event
+ * @param {HTMLFormElement} second_screen
+ * @param {HTMLDialogElement} contract_dialog
  */
-function handleAddContractBtnClick(event) {
-    event.preventDefault()
+function handleAddContractBtnClick(second_screen, contract_dialog) {
+  const description = document.getElementById("description");
+  if (!description || !(description instanceof HTMLInputElement)) throw new Error();
 
-    if (!second_screen.checkValidity()) {
-        console.error("Form isn't valid")
-    }
+  const amount = document.getElementById("amount");
+  if (!amount || !(amount instanceof HTMLInputElement)) throw new Error();
+  const val = Number.parseInt(amount.value);
+  if (Number.isNaN(val)) throw new Error();
 
-    /** @type HTMLInputElement */
-    const description = document.getElementById("description")
-    /** @type HTMLInputElement */
-    const amount = document.getElementById("amount")
-    /** @type HTMLSelectElement */
-    const money_provider = document.getElementById("money_provider")
-    /** @type HTMLSelectElement */
-    const contract_type = document.getElementById("contract_type")
+  const money_provider = document.getElementById("money_provider");
+  if (!money_provider || !(money_provider instanceof HTMLSelectElement)) throw new Error();
 
-    /** @type HTMLInputElement */
-    const localization = document.getElementById("contract_localization")
-    /** @type HTMLInputElement */
-    const delay = document.getElementById("contract_delay")
-    /** @type HTMLInputElement */
-    const control = document.getElementById("contract_control")
-    /** @type HTMLSelectElement */
-    const launch_time = document.getElementById("contract_launch")
-    /** @type HTMLSelectElement */
-    const sign_time = document.getElementById("contract_sign")
+  const contract_type = document.getElementById("contract_type");
+  if (!contract_type || !(contract_type instanceof HTMLSelectElement)) throw new Error();
 
-    const contract = new Contract(description.value, amount.value, money_provider.selectedIndex, launch_time.selectedIndex, sign_time.selectedIndex, control.value, delay.value, localization.value)
+  const localization = document.getElementById("contract_localization");
+  if (!localization || !(localization instanceof HTMLInputElement)) throw new Error();
 
-    if (!ac.add_contract(mp, contract, contract_type.selectedIndex)) {
-        alert("Could not add contract")
-        console.log(contract.render())
-        return
-    }
-    // refresh_dom_contracts(ac.contracts())
-    ac.contracts().forEach(c => console.log(c.render()))
-    contract_dialog.close()
+  const delay = document.getElementById("contract_delay");
+  if (!delay || !(delay instanceof HTMLInputElement)) throw new Error();
+  const delay2 = Number.parseInt(delay.value);
+  if (Number.isNaN(delay2)) throw new Error();
+
+  const control = document.getElementById("contract_control");
+  if (!control || !(control instanceof HTMLInputElement)) throw new Error();
+
+  const launch_time = document.getElementById("contract_launch");
+  if (!launch_time || !(launch_time instanceof HTMLSelectElement)) throw new Error();
+
+  const sign_time = document.getElementById("contract_sign");
+  if (!sign_time || !(sign_time instanceof HTMLSelectElement)) throw new Error();
+
+  const contract = new Contract(description.value, val, money_provider.selectedIndex, launch_time.selectedIndex, sign_time.selectedIndex, proc.control(), delay2, localization.value);
+
+  if (!ac.add_contract(mp, contract, contract_type.selectedIndex)) {
+    alert("Could not add contract");
+    console.log(contract.render());
+    return;
+  }
+  // refresh_dom_contracts(ac.contracts())
+  ac.contracts().forEach(c => console.log(c.render()));
+  contract_dialog.close();
 }
 
 //TODO: find a suitable layout to show contracts
@@ -265,62 +292,99 @@ function handleAddContractBtnClick(event) {
  * @param {Contract[]} contracts 
  */
 function refresh_dom_contracts(contracts) {
-    const contractsElt = document.getElementById("contracts")
-    contractsElt.innerHTML = ""
-    for (let i = 0; i < contracts.length; i++) {
-        const contract = contracts[i]
+  const contractsElt = document.getElementById("contracts");
+  if (!contractsElt) throw new Error();
 
-        /** @type HTMLTemplateElement **/
-        const template = document.getElementById("contract_template")
-        /** @type Node **/
-        const node = template.content.cloneNode(true)
+  contractsElt.innerHTML = "";
+  for (let i = 0; i < contracts.length; i++) {
+    const contract = contracts[i];
 
-        /** @type HTMLParagraphElement **/
-        const noElt = node.querySelector(".contract_no .let")
-        /** @type HTMLParagraphElement **/
-        const descriptionElt = node.querySelector(".contract_description .let")
-        /** @type HTMLParagraphElement **/
-        const amountElt = node.querySelector(".contract_amount .let")
-        /** @type HTMLParagraphElement **/
-        const typeElt = node.querySelector(".contract_type .let")
-        /** @type HTMLParagraphElement **/
-        const providerElt = node.querySelector(".contract_provider .let")
-        /** @type HTMLParagraphElement **/
-        const modeElt = node.querySelector(".contract_mode .let")
-        /** @type HTMLParagraphElement **/
-        const launchElt = node.querySelector(".contract_launch .let")
-        /** @type HTMLParagraphElement **/
-        const signElt = node.querySelector(".contract_sign .let")
-        /** @type HTMLParagraphElement **/
-        const controlElt = node.querySelector(".contract_control .let")
-        /** @type HTMLParagraphElement **/
-        const localizationElt = node.querySelector(".contract_localization .let")
-        /** @type HTMLParagraphElement **/
-        const delayElt = node.querySelector(".contract_delay .let")
+    const template = document.getElementById("contract_template");
+    if (!template || !(template instanceof HTMLTemplateElement)) throw new Error();
 
-        noElt.textContent = contract.no()
-        descriptionElt.textContent = contract.description()
-        providerElt.textContent = MoneyProvider[contract.provider()]
-        amountElt.textContent = fmt.format(contract.amount())
+    const node = template.content.cloneNode(true);
+    if (!node || !(node instanceof DocumentFragment)) throw new Error();
 
-        const contract_type = contract.cinfo().ctype();
-        typeElt.textContent = ContractType[contract_type] //ContractType[contract.cinfo()]
+    const noElt = node.querySelector(".contract_no .let");
+    if (!noElt || !(noElt instanceof HTMLParagraphElement)) throw new Error();
 
-        const contract_mode = contract.cinfo().mode();
-        console.log(contract_mode)
-        if (Array.isArray(contract_mode)) {
-            modeElt.textContent = contract_mode.map(c => Mode[c]).join(",")
-        } else {
-            modeElt.textContent = Mode[contract_mode]
-        }
+    const descriptionElt = node.querySelector(".contract_description .let");
+    if (!descriptionElt || !(descriptionElt instanceof HTMLParagraphElement)) throw new Error();
 
-        launchElt.textContent = contract.launch()
-        signElt.textContent = contract.sign()
-        controlElt.textContent = contract.control() ? "OUI" : "NON"
-        localizationElt.textContent = contract.localization(),
-            delayElt.textContent = contract.delay()
+    const amountElt = node.querySelector(".contract_amount .let");
+    if (!amountElt || !(amountElt instanceof HTMLParagraphElement)) throw new Error();
 
-        contractsElt.appendChild(node)
-    }
-    console.log(contracts.length)
+    const typeElt = node.querySelector(".contract_type .let");
+    if (!typeElt || !(typeElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const providerElt = node.querySelector(".contract_provider .let");
+    if (!providerElt || !(providerElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const modeElt = node.querySelector(".contract_mode .let");
+    if (!modeElt || !(modeElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const launchElt = node.querySelector(".contract_launch .let");
+    if (!launchElt || !(launchElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const signElt = node.querySelector(".contract_sign .let");
+    if (!signElt || !(signElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const controlElt = node.querySelector(".contract_control .let");
+    if (!controlElt || !(controlElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const localizationElt = node.querySelector(".contract_localization .let");
+    if (!localizationElt || !(localizationElt instanceof HTMLParagraphElement)) throw new Error();
+
+    const delayElt = node.querySelector(".contract_delay .let");
+    if (!delayElt || !(delayElt instanceof HTMLParagraphElement)) throw new Error();
+
+    noElt.textContent = contract.no();
+    descriptionElt.textContent = contract.description();
+    providerElt.textContent = MoneyProvider[contract.provider()];
+    amountElt.textContent = fmt.format(contract.amount());
+
+    const contract_type = contract.cinfo().ctype();
+    typeElt.textContent = contract_type.map(ct => ContractType[ct]).join(",");
+
+    const contract_mode = contract.cinfo().mode();
+    modeElt.textContent = contract_mode.map(c => Mode[c]).join(",");
+
+    launchElt.textContent = contract.launch();
+    signElt.textContent = contract.sign();
+    controlElt.textContent = contract.procedure().control() ? "OUI" : "NON";
+    localizationElt.textContent = contract.localization();
+    delayElt.textContent = contract.delay().toString();
+
+    contractsElt.appendChild(node);
+  }
+  console.log(contracts.length);
 }
+/**
+ * @param {HTMLInputElement} input
+ */
+function setupValidation(input) {
+  innerSetup(input);
+  input.addEventListener("input", () => {
+    innerSetup(input);
+  });
+
+  /**
+   * @param {HTMLInputElement} input
+   */
+  function innerSetup(input) {
+    if (input.validity.valueMissing) {
+      input.setCustomValidity(`Vous devez remplir ce champ`);
+    } else if (input.validity.badInput) {
+      //NOTE: This only works because I only have input of type text and number
+      input.setCustomValidity("Vous devez entrer un nombre");
+    } else if (input.validity.rangeUnderflow) {
+      input.setCustomValidity(`Vous devez entrer un nombre superieur ou egale a ${fmt.format(Number.parseInt(input.min))}`);
+    } else if (input.validity.rangeOverflow) {
+      input.setCustomValidity(`Vous devez entrer un nombre inferieur ou egale a ${input.max}`);
+    }
+    else {
+      input.setCustomValidity("");
+    }
+  }
+}
+

--- a/style.css
+++ b/style.css
@@ -1,16 +1,17 @@
 tr {
   border-bottom: 1px solid #ddd;
 }
+
 tr:hover {
   background-color: #d6eeee;
 }
 
-input:invalid {
-  border-color: red;
+input:focus {
+  outline: none;
 }
 
-input:invalid:focus {
-  outline-color: red;
+input:invalid {
+  outline: 2px solid red;
 }
 
 fieldset {


### PR DESCRIPTION
- Hello
- Hello 101
- 102
- Adding marches
- finishing & polishing
- adding
- feat(portability): Convert the core logic to rust
- feat(wasm): Use of `wasm-pack` for wasm support
- refactor(wasm): Adapt the client side to work with the new backend
- refactor(wasm): Adapt the client side to work with the new backend
- In preparation for a merge
- feat(portability): Convert the core logic to rust
- feat(wasm): Use of `wasm-pack` for wasm support
- refactor(wasm): Adapt the client side to work with the new backend
- refactor(wasm): Adapt the client side to work with the new backend
- In preparation for a merge
- fix(#3): Add form validation
